### PR TITLE
Documentation for Approver Role for User Groups

### DIFF
--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -14,13 +14,13 @@ The Groups Configuration Screen in Kickstarter has a checkbox which allows the u
  
 ![approver1](https://user-images.githubusercontent.com/9421117/36286403-74ae8e34-1264-11e8-9c65-1432bef850ee.png)
 
-## Associating APIs to approvers 
+### Associating APIs to approvers 
 
 The Alternative IDs field of the approver group must contain the Group IDs associated with the APIs, enabling the approver to see their approval requests when logging into the Wicked API Portal. For example, our gateway has an API, 'Charge Reader'.  To allow members of the 'Electric Car API Approver' group to see approval requests for this API in the portal, the Group IDs for API 'Charge Reader' is added to the approver group.  
  
 ![approver2](https://user-images.githubusercontent.com/9421117/36286407-7bc71e66-1264-11e8-95dc-967ef6d47381.png)
 
-## API Portal UI 
+### API Portal UI 
 
 The API portal menu for an approver includes a link to 'Pending Approvals' 
 ![approver3](https://user-images.githubusercontent.com/9421117/36286412-8387c5f6-1264-11e8-83e8-45216cf0fa34.png)

--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -8,16 +8,19 @@ Approver role provides flexibility for use of the Wicked API portal across an en
 ## How it works 
 
 1.  **Configuring Groups to have approval role** 
+
 The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
  _Note: **This change does not impact existing admin group functionality**._ 
  
 ![approver1](https://user-images.githubusercontent.com/9421117/36286403-74ae8e34-1264-11e8-9c65-1432bef850ee.png)
 
 2. **Associating APIs to approvers** 
+
 The Alternative IDs field of the approver group must contain the Group IDs associated with the APIs, enabling the approver to see their approval requests when logging into the Wicked API Portal. For example, our gateway has an API, 'Charge Reader'.  To allow members of the 'Electric Car API Approver' group to see approval requests for this API in the portal, the Group IDs for API 'Charge Reader' is added to the approver group.  
  
 ![approver2](https://user-images.githubusercontent.com/9421117/36286407-7bc71e66-1264-11e8-95dc-967ef6d47381.png)
 
 3. **API Portal UI Changes** 
- The API portal menu for an approver includes a link to 'Pending Approvals' 
+
+The API portal menu for an approver includes a link to 'Pending Approvals' 
 ![approver3](https://user-images.githubusercontent.com/9421117/36286412-8387c5f6-1264-11e8-83e8-45216cf0fa34.png)

--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -1,0 +1,23 @@
+# Approver role for User Groups 
+
+## Introduction 
+The group feature now supports an approval role.  The approver role allows for controlling which users have the ability to approve API subscription requests.  
+ 
+Approver role provides flexibility for use of the Wicked API portal across an enterprise, where there may be business or commercial need to segment who has the responsibility to take action on an API approval request. By introducing the approver group type, we are able to control who sees what API approval requests.  
+
+## How it works 
+
+1.  **Configuring Groups to have approval role** 
+The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
+ 
+ _Note: **This change does not impact existing admin group functionality**._ 
+![approver1](https://user-images.githubusercontent.com/9421117/36286403-74ae8e34-1264-11e8-9c65-1432bef850ee.png)
+
+2. **Associating APIs to approvers** 
+The Alternative IDs field of the approver group must contain the Group IDs associated with the APIs, enabling the approver to see their approval requests when logging into the Wicked API Portal. For example, our gateway has an API, 'Charge Reader'.  To allow members of the 'Electric Car API Approver' group to see approval requests for this API in the portal, the Group IDs for API 'Charge Reader' is added to the approver group.  
+ 
+![approver2](https://user-images.githubusercontent.com/9421117/36286407-7bc71e66-1264-11e8-95dc-967ef6d47381.png)
+
+3. **API Portal UI Changes** 
+ The API portal menu for an approver includes a link to 'Pending Approvals' 
+![approver3](https://user-images.githubusercontent.com/9421117/36286412-8387c5f6-1264-11e8-83e8-45216cf0fa34.png)

--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -10,8 +10,8 @@ Approver role provides flexibility for use of the Wicked API portal across an en
 1.  **Configuring Groups to have approval role** 
 The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
  
- _Note: **This change does not impact existing admin group functionality**._ 
 ![approver1](https://user-images.githubusercontent.com/9421117/36286403-74ae8e34-1264-11e8-9c65-1432bef850ee.png)
+ _Note: **This change does not impact existing admin group functionality**._ 
 
 2. **Associating APIs to approvers** 
 The Alternative IDs field of the approver group must contain the Group IDs associated with the APIs, enabling the approver to see their approval requests when logging into the Wicked API Portal. For example, our gateway has an API, 'Charge Reader'.  To allow members of the 'Electric Car API Approver' group to see approval requests for this API in the portal, the Group IDs for API 'Charge Reader' is added to the approver group.  

--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -7,20 +7,20 @@ Approver role provides flexibility for use of the Wicked API portal across an en
 
 ## How it works 
 
-1.  **Configuring Groups to have approval role** 
+### Configuring Groups to have approval role
 
 The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
  _Note: **This change does not impact existing admin group functionality**._ 
  
 ![approver1](https://user-images.githubusercontent.com/9421117/36286403-74ae8e34-1264-11e8-9c65-1432bef850ee.png)
 
-2. **Associating APIs to approvers** 
+## Associating APIs to approvers 
 
 The Alternative IDs field of the approver group must contain the Group IDs associated with the APIs, enabling the approver to see their approval requests when logging into the Wicked API Portal. For example, our gateway has an API, 'Charge Reader'.  To allow members of the 'Electric Car API Approver' group to see approval requests for this API in the portal, the Group IDs for API 'Charge Reader' is added to the approver group.  
  
 ![approver2](https://user-images.githubusercontent.com/9421117/36286407-7bc71e66-1264-11e8-95dc-967ef6d47381.png)
 
-3. **API Portal UI Changes** 
+## API Portal UI 
 
 The API portal menu for an approver includes a link to 'Pending Approvals' 
 ![approver3](https://user-images.githubusercontent.com/9421117/36286412-8387c5f6-1264-11e8-83e8-45216cf0fa34.png)

--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -12,13 +12,14 @@ Approver role provides flexibility for use of the Wicked API portal across an en
 The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
  _Note: **This change does not impact existing admin group functionality**._ 
  
-![approver1](https://user-images.githubusercontent.com/9421117/36286403-74ae8e34-1264-11e8-9c65-1432bef850ee.png)
+![snip20180222_6](https://user-images.githubusercontent.com/9421117/36571212-711816e2-17ea-11e8-853d-318ccb19bb84.png)
 
 ### Associating APIs to approvers 
 
-The Alternative IDs field of the approver group must contain the Group IDs associated with the APIs, enabling the approver to see their approval requests when logging into the Wicked API Portal. For example, our gateway has an API, 'Charge Reader'.  To allow members of the 'Electric Car API Approver' group to see approval requests for this API in the portal, the Group IDs for API 'Charge Reader' is added to the approver group.  
- 
-![approver2](https://user-images.githubusercontent.com/9421117/36286407-7bc71e66-1264-11e8-95dc-967ef6d47381.png)
+Approver needs to be part of the group that is associated with the API that he/she has the responsibility to approve, enabling the approver to see their approval requests when logging into the Wicked API Portal.  
+For example, our gateway has an API, 'Charge Reader'.  To approver needs to be part of the  'Charge Reader' group to see approval requests for this API in the portal.
+
+![snip20180222_7](https://user-images.githubusercontent.com/9421117/36571218-776b7b9c-17ea-11e8-850c-79ebb0f865ac.png)
 
 ### API Portal UI 
 

--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -7,7 +7,7 @@ Approver role provides flexibility for use of the Wicked API portal across an en
 
 ## How it works 
 
-### Configuring Groups to have approval role
+### Configuring Groups to have approver role
 
 The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
  _Note: **This change does not impact existing admin group functionality**._ 
@@ -23,4 +23,5 @@ The Alternative IDs field of the approver group must contain the Group IDs assoc
 ### API Portal UI 
 
 The API portal menu for an approver includes a link to 'Pending Approvals' 
+
 ![approver3](https://user-images.githubusercontent.com/9421117/36286412-8387c5f6-1264-11e8-83e8-45216cf0fa34.png)

--- a/doc/defining-user-groups-approver-role.md
+++ b/doc/defining-user-groups-approver-role.md
@@ -9,9 +9,9 @@ Approver role provides flexibility for use of the Wicked API portal across an en
 
 1.  **Configuring Groups to have approval role** 
 The Groups Configuration Screen in Kickstarter has a checkbox which allows the user to assign a new group type called 'approver' as part of Group Definition. For example, we create a new group called 'Electric Car API Approver' and assign it as approver 
+ _Note: **This change does not impact existing admin group functionality**._ 
  
 ![approver1](https://user-images.githubusercontent.com/9421117/36286403-74ae8e34-1264-11e8-9c65-1432bef850ee.png)
- _Note: **This change does not impact existing admin group functionality**._ 
 
 2. **Associating APIs to approvers** 
 The Alternative IDs field of the approver group must contain the Group IDs associated with the APIs, enabling the approver to see their approval requests when logging into the Wicked API Portal. For example, our gateway has an API, 'Charge Reader'.  To allow members of the 'Electric Car API Approver' group to see approval requests for this API in the portal, the Group IDs for API 'Charge Reader' is added to the approver group.  

--- a/doc/defining-user-groups.md
+++ b/doc/defining-user-groups.md
@@ -47,6 +47,10 @@ All configurations should contain an `admin` user group. This is the default Adm
 
 As described in the [setup documentation](creating-a-portal-configuration.md), by default there is exactly one Administrator predefined, the Admin user with the user id `1` (email `admin@foo.com`, password `wicked`); leverage this user to grant admin rights to your own user (if you are the admin) and subsequently remove the password from the default admin user to prevent people logging in with that super user.
 
+**See also**:
+
+* [Approver role for User Groups](defining-user-groups-approver-role.md)
+
 ## User group use cases
 
 The followings sections describe typical use cases for user groups.


### PR DESCRIPTION
# Changelog 

- Added link in `defining-user-groups.md` to Approver role documentation
- Added document `defining-user-groups-approver-role.md` for Approver role
