### PR TITLE
Fixed typo in Wicked Deployment. VERISON changed to VERSION

### DIFF
--- a/wicked/README.md
+++ b/wicked/README.md
@@ -33,7 +33,7 @@ It is also assumed that you have some knowledge of Helm, and that you have run `
 If that is set and done, you may now install wicked using the Helm chart. Move into a suitable directory, and then download the chart using `helm fetch`:
 
 ```
-$ export WICKED_VERISON=0.12.1 # Possibly adapt to the latest version
+$ export WICKED_VERSION=0.12.1 # Possibly adapt to the latest version
 $ helm fetch --untar https://github.com/Haufe-Lexware/wicked.haufe.io/releases/download/v${WICKED_VERSION}/wicked-${WICKED_VERSION}.tgz
 ```
 


### PR DESCRIPTION
VERSION was misspelled as VERISON under the "Wicked Deployment" heading.