### PR TITLE
Re-order columns in download to CSV 

### DIFF
--- a/src/ui/routes/admin.js
+++ b/src/ui/routes/admin.js
@@ -115,12 +115,12 @@ router.get('/approvals_csv', mustBeAdminOrApproverMiddleware, function (req, res
             if (err)
                 return next(err);
             const outStream = fs.createWriteStream(path);
-            outStream.write('User;Application;Description;Trusted;Api;Plan;Date (UTC)\n');
+            outStream.write('User;Application;Trusted;Api;Plan;Date (UTC);Description\n');
             apiResponse.forEach(item => {
                 let trusted = item.application.trusted ? 'Yes' : '-';
                 let date = utils.dateFormat(new Date(item.changedDate), "%Y-%m-%d %H:%M:%S", true);
                 let description = item.application.description ? item.application.description : 'No Description';
-                const approvalsLine = `${item.user.email}; ${item.application.name}; ${description}; ${trusted}; ${item.api.name}; ${item.plan.name}; ${date}\n`;
+                const approvalsLine = `${item.user.email}; ${item.application.name}; ${trusted}; ${item.api.name}; ${item.plan.name}; ${date}; ${description}\n`;
                 debug(approvalsLine);
                 outStream.write(approvalsLine);
             });


### PR DESCRIPTION
Re-order columns in download to CSV to move description column to last, just for better usability