### PR TITLE
upgrade helm apiVersion for ingress resource; introduce more configuration for deployment

### DIFF
--- a/wicked/templates/ingress.yaml
+++ b/wicked/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}-portal-ingress
@@ -24,11 +24,14 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "fullname" . }}-portal
-          servicePort: 3000
+          service:
+            name: {{ template "fullname" . }}-portal
+            port:
+              number: 3000
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}-gateway-ingress
@@ -53,7 +56,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "fullname" . }}-kong
-          servicePort: 8000
+          service:
+            name: {{ template "fullname" . }}-kong
+            port:
+              number: 8000
 {{- end -}}

--- a/wicked/templates/kong-deployment.yaml
+++ b/wicked/templates/kong-deployment.yaml
@@ -27,6 +27,10 @@ spec:
         prometheus.io/path: '/metrics'
         prometheus.io/port:  '8001'
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}

--- a/wicked/templates/portal-api-deployment.yaml
+++ b/wicked/templates/portal-api-deployment.yaml
@@ -26,6 +26,10 @@ spec:
         prometheus.io/path: '/metrics'
         prometheus.io/port:  '3001'
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}

--- a/wicked/templates/portal-auth-deployment.yaml
+++ b/wicked/templates/portal-auth-deployment.yaml
@@ -26,6 +26,10 @@ spec:
         prometheus.io/path: '/metrics'
         prometheus.io/port:  '3010'
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}

--- a/wicked/templates/portal-chatbot-deployment.yaml
+++ b/wicked/templates/portal-chatbot-deployment.yaml
@@ -23,6 +23,11 @@ spec:
         service: {{ template "fullname" . }}-chatbot
         wicked: "true"
     spec:
+
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}

--- a/wicked/templates/portal-deployment.yaml
+++ b/wicked/templates/portal-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         service: {{ template "fullname" . }}-portal
         wicked: "true"
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}

--- a/wicked/templates/portal-kong-adapter-deployment.yaml
+++ b/wicked/templates/portal-kong-adapter-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         service: {{ template "fullname" . }}-kong-adapter
         wicked: "true"
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}

--- a/wicked/templates/portal-mailer-deployment.yaml
+++ b/wicked/templates/portal-mailer-deployment.yaml
@@ -23,8 +23,13 @@ spec:
         service: {{ template "fullname" . }}-mailer
         wicked: "true"
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
-      serviceAccountName: {{ template "fullname" . }}-role
+      serviceAccountName:
+{{ template "fullname" . }}-role
 {{- end }}
       initContainers:
       - name: {{ template "fullname" . }}-mailer-init

--- a/wicked/templates/postgres-deployment.yaml
+++ b/wicked/templates/postgres-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         service: {{ template "fullname" . }}-kong-database
         wicked: "true"
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}

--- a/wicked/templates/redis-deployment.yaml
+++ b/wicked/templates/redis-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         service: {{ template "fullname" . }}-redis
         wicked: "true"
     spec:
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 10 }}
+{{- end }}
 {{- if .Values.useRbac }}
       serviceAccountName: {{ template "fullname" . }}-role
 {{- end }}


### PR DESCRIPTION
When deploying that helm chart to k8s 1.20.7 I have got an issue due to found ingress api version.
Changed to 'networking.k8s.io/v1'.

Also in our context pods were assigned to wrong nodes of wrong node group.
I added in deployment template an optional  config
{{- if .Values.nodeSelector }}
      nodeSelector:
      {{ toYaml .Values.nodeSelector | indent 10 }}
{{- end }}

If such value is written in override.yaml:
...
nodeSelector:
  stack: app
...
it will be applied to deployment config file.