### PR TITLE
SAML: allowing idpOptions sso_urls to be parameterized

### DIFF
--- a/src/auth/src/common/generic-router.ts
+++ b/src/auth/src/common/generic-router.ts
@@ -452,6 +452,13 @@ export class GenericOAuth2Router {
             // Support prefilled username
             authRequest.prefill_username = givenPrefillUsername;
 
+            authRequest.options = {};
+            Object.keys(req.query).forEach(key => {
+                if (key.startsWith("x_")) {
+                    authRequest.options[key.substring(2)] = req.query[key];
+                }
+            })
+
             // Validate parameters first now (TODO: This is pbly feasible centrally,
             // it will be the same for all Auth Methods).
             let subscriptionInfo: WickedSubscriptionInfo;
@@ -992,8 +999,7 @@ export class GenericOAuth2Router {
         const scopeRequest: PassthroughScopeRequest = {
             scope: scope,
             auth_method: this.authMethodId,
-            profile: profile,
-            data: data
+            profile: profile
         };
         debug(JSON.stringify(scopeRequest));
         async.retry({

--- a/src/auth/src/common/generic-router.ts
+++ b/src/auth/src/common/generic-router.ts
@@ -24,6 +24,7 @@ import { GrantManager } from './grant-manager';
 const ERROR_TIMEOUT = 500; // ms
 const EXTERNAL_URL_INTERVAL = 500;
 const EXTERNAL_URL_RETRIES = 10;
+const ADDITIONAL_AUTHORIZE_OPTION_VALUES_REGEX = /^([a-zA-Z0-9][a-zA-Z0-9-_.]+)$/;
 
 export class GenericOAuth2Router {
 
@@ -454,8 +455,9 @@ export class GenericOAuth2Router {
 
             authRequest.options = {};
             Object.keys(req.query).forEach(key => {
-                if (key.startsWith("x_")) {
-                    authRequest.options[key.substring(2)] = req.query[key];
+                let value = req.query[key];
+                if (key.startsWith("x_") && ADDITIONAL_AUTHORIZE_OPTION_VALUES_REGEX.test(value)) {
+                    authRequest.options[key.substring(2)] = value;
                 }
             })
 

--- a/src/auth/src/common/generic-router.ts
+++ b/src/auth/src/common/generic-router.ts
@@ -1001,7 +1001,8 @@ export class GenericOAuth2Router {
         const scopeRequest: PassthroughScopeRequest = {
             scope: scope,
             auth_method: this.authMethodId,
-            profile: profile
+            profile: profile,
+            data: data
         };
         debug(JSON.stringify(scopeRequest));
         async.retry({

--- a/src/auth/src/common/types.ts
+++ b/src/auth/src/common/types.ts
@@ -54,7 +54,9 @@ export interface AuthRequest extends OAuth2Request {
     prefill_username?: string,
     validNamespaces?: string[],
     // Used in the SAML case
-    requestId?: string
+    requestId?: string,
+    // additional parameters passed to the authorization request
+    options?: any
 }
 
 export interface AuthRequestCallback {

--- a/src/auth/src/providers/saml.ts
+++ b/src/auth/src/providers/saml.ts
@@ -75,7 +75,7 @@ export class SamlIdP implements IdentityProvider {
 
     private getIdentityProvider(req): any {
         const authRequest = utils.getAuthRequest(req, this.authMethodId);
-        const key = authRequest.options ? JSON.stringify(authRequest.options) : "";
+        const key = (authRequest.options && Object.keys(authRequest.options).length > 0) ? JSON.stringify(authRequest.options) : "global";
         if (!this.identityProviders[key]) {
             const clonedIdpOptions = Object.assign({}, this.authMethodConfig.idpOptions);
             clonedIdpOptions.sso_login_url = mustache.render(clonedIdpOptions.sso_login_url, authRequest);


### PR DESCRIPTION
With this PR additional parameters that are passes to the authorization request, start with x_ and match a 'id-string' pattern are added to the authRequest structure that is kept in the session in a new property options. Additionally, if options have been added to the request the sso_login_url and sso_logout_url are mustache-processed with the authRequest as parameter.

This allows for idpOptions like
`"sso_login_url": "https://myidp.org:/auth/SSOPOST/metaAlias/idp-{{{options.auth_realm}}}"`
given that the authorization request as a parameter `x_auth_realm=some-valid-value`